### PR TITLE
QIF uses a single colon between names in the account hierarchy, rather

### DIFF
--- a/lib/gnucash/account.rb
+++ b/lib/gnucash/account.rb
@@ -99,7 +99,7 @@ module Gnucash
       if @parent_id
         parent = @book.find_account_by_id(@parent_id)
         if parent and parent.type != 'ROOT'
-          prefix = parent.full_name + "::"
+          prefix = parent.full_name + ":"
         end
       end
       prefix + name


### PR DESCRIPTION
than two colons (e.g.
http://en.wikipedia.org/wiki/Quicken_Interchange_Format).
