### PR TITLE
custom inspect implementation

### DIFF
--- a/lib/gnucash.rb
+++ b/lib/gnucash.rb
@@ -1,3 +1,4 @@
+require_relative "gnucash/support"
 require_relative "gnucash/account"
 require_relative "gnucash/account_transaction"
 require_relative "gnucash/book"

--- a/lib/gnucash/account.rb
+++ b/lib/gnucash/account.rb
@@ -1,6 +1,8 @@
 module Gnucash
   # Represent a GnuCash account object.
   class Account
+    include Support::LightInspect
+
     # @return [String] The name of the account (unqualified).
     attr_reader :name
 
@@ -103,6 +105,14 @@ module Gnucash
         idx = (imin + imax) / 2
       end
       @balances[idx][:value]
+    end
+
+    # Attributes available for inspection
+    #
+    # @return [Array<Symbol>] Attributes used to build the inspection string
+    # @see Gnucash::Support::LightInspect
+    def attributes
+      %i[id name description type placeholder parent_id]
     end
 
     private

--- a/lib/gnucash/account_transaction.rb
+++ b/lib/gnucash/account_transaction.rb
@@ -1,6 +1,8 @@
 module Gnucash
   # Class to link a transaction object to an Account.
   class AccountTransaction
+    include Support::LightInspect
+
     # @return [Value] The transaction value for the linked account.
     attr_reader :value
 
@@ -20,6 +22,14 @@ module Gnucash
     # Pass through any missing method calls to the linked Transaction object.
     def method_missing(*args)
       @real_txn.send(*args)
+    end
+
+    # Attributes available for inspection
+    #
+    # @return [Array<Symbol>] Attributes used to build the inspection string
+    # @see Gnucash::Support::LightInspect
+    def attributes
+      %i[value]
     end
   end
 end

--- a/lib/gnucash/book.rb
+++ b/lib/gnucash/book.rb
@@ -4,6 +4,8 @@ require "nokogiri"
 module Gnucash
   # Represent a GnuCash Book.
   class Book
+    include Support::LightInspect
+
     # @return [Array<Account>] Accounts in the book.
     attr_reader :accounts
 
@@ -57,6 +59,14 @@ module Gnucash
     # @return [Account, nil] Account object, or nil if not found.
     def find_account_by_full_name(full_name)
       @accounts.find { |a| a.full_name == full_name }
+    end
+
+    # Attributes available for inspection
+    #
+    # @return [Array<Symbol>] Attributes used to build the inspection string
+    # @see Gnucash::Support::LightInspect
+    def attributes
+      %i[start_date end_date]
     end
 
     private

--- a/lib/gnucash/support.rb
+++ b/lib/gnucash/support.rb
@@ -1,0 +1,7 @@
+require_relative "support/light_inspect"
+
+module Gnucash
+  module Support
+    include LightInspect
+  end
+end

--- a/lib/gnucash/support/light_inspect.rb
+++ b/lib/gnucash/support/light_inspect.rb
@@ -1,0 +1,23 @@
+module Gnucash
+  module Support
+    # Allows lightweight inspection os Gnucash models by avoiding fetch XML nodes.
+    module LightInspect
+
+      # Attributes available for inspection
+      #
+      # @return [Array<Symbol>] Attributes used to build the inspection string
+      def attributes
+        []
+      end
+
+      # Custom implementation using only selected attributes.
+      #
+      # @return [String] Stringified version of the object
+      # @see #attributes
+      def inspect
+        inspection = attributes.map { |att| "#{att}: #{send(att)}" }.join(", ")
+        "#<#{self.class} #{inspection}>"
+      end
+    end
+  end
+end

--- a/lib/gnucash/transaction.rb
+++ b/lib/gnucash/transaction.rb
@@ -7,6 +7,8 @@ module Gnucash
   # Splits are created as AccountTransaction objects which are associated
   # with an individual account.
   class Transaction
+    include Support::LightInspect
+
     # @return [Date] The date of the transaction.
     attr_reader :date
 
@@ -45,6 +47,14 @@ module Gnucash
           value: value,
         }
       end
+    end
+
+    # Attributes available for inspection
+    #
+    # @return [Array<Symbol>] Attributes used to build the inspection string
+    # @see Gnucash::Support::LightInspect
+    def attributes
+      %i[id date description splits]
     end
   end
 end

--- a/lib/gnucash/value.rb
+++ b/lib/gnucash/value.rb
@@ -3,6 +3,7 @@ module Gnucash
   # for accuracy in computations.
   class Value
     include Comparable
+    include Support::LightInspect
 
     # @return [Integer] The raw, undivided integer value.
     attr_reader :val
@@ -140,6 +141,14 @@ module Gnucash
     def ==(other)
       lcm_div = @div.lcm(other.div)
       (@val * (lcm_div / @div)) == (other.val * (lcm_div / other.div))
+    end
+
+    # Attributes available for inspection
+    #
+    # @return [Array<Symbol>] Attributes used to build the inspection string
+    # @see Gnucash::Support::LightInspect
+    def attributes
+      %i[val div]
     end
   end
 end

--- a/spec/gnucash/account_spec.rb
+++ b/spec/gnucash/account_spec.rb
@@ -49,5 +49,9 @@ module Gnucash
       expect(@income.placeholder).to be_truthy
       expect(@salary.placeholder).to be_falsey
     end
+
+    it "avoid inspection of heavier attributes" do
+      expect(@salary.inspect).to eq "#<Gnucash::Account id: efebb6cb617971b0a7f62e9d5a204789, name: Salary, description: Salary, type: INCOME, placeholder: , parent_id: 35ab61d46f5404895bf5d4949f8a5593>"
+    end
   end
 end

--- a/spec/gnucash/account_transaction_spec.rb
+++ b/spec/gnucash/account_transaction_spec.rb
@@ -1,0 +1,16 @@
+module Gnucash
+  describe AccountTransaction do
+    before(:all) do
+      @book = Gnucash.open("spec/books/sample.gnucash")
+      @txn = @book.find_account_by_full_name("Assets:Current Assets:Cash in Wallet").transactions.first
+    end
+
+    it "keeps track of the transaction description" do
+      expect(@txn.description).to eq "Opening Balance"
+    end
+
+    it "avoid inspection of heavier attributes" do
+      expect(@txn.inspect).to eq "#<Gnucash::AccountTransaction value: 100.00>"
+    end
+  end
+end

--- a/spec/gnucash/book_spec.rb
+++ b/spec/gnucash/book_spec.rb
@@ -34,6 +34,10 @@ module Gnucash
       it "lets you find an account by full name" do
         expect(@subject.find_account_by_full_name("Assets:Current Assets:Savings Account").id).to eq "67e6e7daadc35716eb6152769373e974"
       end
+
+      it "avoid inspection of heavier attributes" do
+        expect(@subject.inspect).to eq "#<Gnucash::Book start_date: 2007-01-01, end_date: 2012-12-28>"
+      end
     end
   end
 end

--- a/spec/gnucash/transaction_spec.rb
+++ b/spec/gnucash/transaction_spec.rb
@@ -29,11 +29,10 @@ module Gnucash
     context "without errors" do
       before(:all) do
         @book = Gnucash.open("spec/books/sample.gnucash")
-        @txn = @book.find_account_by_full_name("Assets:Current Assets:Cash in Wallet").transactions.first
       end
 
-      it "keeps track of the transaction description" do
-        expect(@txn.description).to eq "Opening Balance"
+      it "avoid inspection of heavier attributes" do
+        expect(@book.transactions.first.inspect).to eq "#<Gnucash::Transaction id: 12efba30f14dc6cd4c3ffe2994de8284, date: 2007-01-01, description: Opening Balance, splits: [{:account=>#<Gnucash::Account id: 849f778995e8ecf8d4b96940afbbdcd7, name: Checking Account, description: Checking Account, type: BANK, placeholder: , parent_id: c8e868259d70f6491f9e70ffdf6634ee>, :value=>#<Gnucash::Value val: 30000, div: 100>}, {:account=>#<Gnucash::Account id: 23bea6468ee7b4acb4db4b3f54598a71, name: Opening Balances, description: Opening Balances, type: EQUITY, placeholder: , parent_id: ea7fe8b8abd560bef49826f68387ca78>, :value=>#<Gnucash::Value val: -30000, div: 100>}]>"
       end
     end
   end

--- a/spec/gnucash/value_spec.rb
+++ b/spec/gnucash/value_spec.rb
@@ -1,7 +1,7 @@
 module Gnucash
   describe Value do
-    describe '.zero' do
-      it 'creates a Value object with value 0' do
+    describe ".zero" do
+      it "creates a Value object with value 0" do
         expect(Value.zero.val).to eq 0
       end
     end
@@ -99,6 +99,10 @@ module Gnucash
       expect(Value.new("1234/10000") < Value.new("100/100")).to be_truthy
       expect(Value.new(7, 100) + Value.new(17, 1000)).to eq Value.new(87, 1000)
       expect(Value.new(80, 100) - Value.new(5, 50)).to eq Value.new(70, 100)
+    end
+
+    it "avoid inspection of heavier attributes" do
+      expect(Value.new("1234/10000").inspect).to eq "#<Gnucash::Value val: 1234, div: 10000>"
     end
 
     context "errors" do


### PR DESCRIPTION
This PR allows a painless experience using this library withing REPL like IRB or PRY.

Essentially these guys use `.inspect` to print the return of every method call, so it will fetch(and print) the full XML structure in the file.

Then:
```shell
$ irb
  > require_relative 'lib/gnucash'
 => true
  > book = Gnucash.open("spec/books/sample.gnucash") # get stuck
```

Now:
```shell
$ irb
  > require_relative 'lib/gnucash'
 => true
  > book = Gnucash.open("spec/books/sample.gnucash")
 => #<Gnucash::Book start_date: 2007-01-01, end_date: 2012-12-28>
```
  