### PR TITLE
Extend balance_on for child account balances.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ delta = act.balance_on("#{year}-12-31") - act.balance_on("#{year - 1}-12-31")
 puts "You've saved #{delta} this year so far!"
 ```
 
+To get the balance of an account, use ```act.balance_on("#{year}-12-31")```.
+To get the total balance of an account with all his childrem accounts,
+use ```act.balance_on("#{year}-12-31", true)```.
+
 ## Contributing
 
 1. Fork it

--- a/spec/gnucash/account_spec.rb
+++ b/spec/gnucash/account_spec.rb
@@ -54,6 +54,12 @@ module Gnucash
       it "includes transactions that occur on the given date" do
         expect(@checking.balance_on("2007-03-27")).to eq Value.new(780000)
       end
+
+      describe 'with child accounts' do
+        it "returns the balance with the balance of the child accounts" do
+          expect(@assets.balance_on("2007-03-27", true)).to eq Value.new(790000)
+        end
+      end
     end
 
     it "stores whether the account was a placeholder" do


### PR DESCRIPTION
Thanks very much for this gem, you saved me a lot of time!

One thing what I missed was the posibility to get aggregated balances for a (placeholder) account which includes the balances of all its children accounts. I added this in this PR by adding a flag to the `balance_on` method.